### PR TITLE
Suppress UserWarning for psycopg2 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Install the required Python packages via:
 
 Optional: If you want to use PostgreSQL, you need to install `psycopg2`:
 
-    pip install psycopg2
+    pip install psycopg2-binary
+
+or `pip install psycopg2` if you want to build the binary yourself (requires a C toolchain).
 
 
 ## Configuration

--- a/backends/postgresql.py
+++ b/backends/postgresql.py
@@ -3,7 +3,9 @@ from contextlib import closing
 from datetime import datetime
 from string import ascii_letters, digits
 from typing import Iterable, List, Tuple, Union
+import warnings
 
+warnings.filterwarnings("ignore", category=UserWarning, module='psycopg2')
 import psycopg2
 
 from backends.backend import Backend, BackendException

--- a/backends/postgresql.py
+++ b/backends/postgresql.py
@@ -5,7 +5,7 @@ from string import ascii_letters, digits
 from typing import Iterable, List, Tuple, Union
 import warnings
 
-warnings.filterwarnings("ignore", category=UserWarning, module='psycopg2')
+warnings.filterwarnings('ignore', 'The psycopg2 wheel package will be renamed from release 2.8', UserWarning, 'psycopg2')
 import psycopg2
 
 from backends.backend import Backend, BackendException


### PR DESCRIPTION
Currently VersionInferrer might show a warning like this:
/usr/local/lib/python3.7/site-packages/psycopg2/__init__.py:144:
UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in
order to keep installing from binary please use "pip install psycopg2-binary"
instead. For details see:
<http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.

This is annoying, therefore this commit suppresses this warning.