### PR TITLE
Update installation instructions for psycopg2 module in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Optional: If you want to use PostgreSQL, you need to install `psycopg2`:
 
     pip install psycopg2-binary
 
-or `pip install psycopg2` if you want to build the binary yourself (requires a C toolchain).
+or `pip install --no-binary :all: psycopg2` (see [official documentation](http://initd.org/psycopg/docs/install.html#disabling-wheel-packages-for-psycopg-2-7)) if you want to build the binary yourself (requires a C toolchain).
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Install the required Python packages via:
 
 Optional: If you want to use PostgreSQL, you need to install `psycopg2`:
 
-    pip install psycopg2
+    pip install psycopg2-binary
+
+or `pip install psycopg2` if you want to build the binary yourself (requires a C toolchain).
 
 
 ## Configuration


### PR DESCRIPTION
The pysogpg2 module shows a warning for the current version, that the binary distribution of the module will be renamed. This PR reflects the official recommendation in the README to fix this warning.

For further discussion see #3.