### PR TITLE
Don't load Majestic Million when URLs are given

### DIFF
--- a/scanning/scanner.py
+++ b/scanning/scanner.py
@@ -32,8 +32,9 @@ class Scanner:
         # majestic million is 1-indexed
         start = skip + 1
         end = count + skip + 1
-        sites = majestic_million.get_sites(start, end)
-        if urls:
+        if urls is None:
+            sites = majestic_million.get_sites(start, end)
+        else:
             # use provided urls instead of majestic domains
             sites = urls[skip:skip + count]
         futures = []


### PR DESCRIPTION
This should improve performace as currenlty the Majestic Million list is always loaded regardless of the given URLs to `scan_sites`. Now the Majestic Million are only loaded if there are no URLs given.