### PR TITLE
Use fallback if no scheme is given in scan URL

### DIFF
--- a/analysis/website_analyzer.py
+++ b/analysis/website_analyzer.py
@@ -34,11 +34,15 @@ class WebsiteAnalyzer:
     def __init__(self, primary_url: str, cache_file: Optional[str] = None):
         self.complete_retrieval = False
         self.dry_run = False
-        self.primary_url = primary_url
         self.retrieved_resources = set()
         self._cache = {}
         if cache_file:
             self._load_cache(cache_file)
+        if not primary_url.startswith(('http://', 'https://')):
+            logging.warning('No scheme was given for the primary URL. Falling back to \'http://\' as scheme.')
+            self.primary_url = 'http://{}'.format(primary_url)
+        else:
+            self.primary_url = primary_url
 
     def __del__(self):
         if self._cache_file:


### PR DESCRIPTION
If no scheme is given for a URL to scan, fall back to `http://` as scheme. Also provide a warning to the user as this might not be expected behaviour. Alternatively this could be an informal message (`logging.INFO`). Feel free to provide feedback :)

Fixes #7