### PR TITLE
Update URL for NVD CVE feed and fix new schema

### DIFF
--- a/cve/cve.py
+++ b/cve/cve.py
@@ -25,21 +25,22 @@ def affected_versions(cve: dict) -> Set[SoftwareVersion]:
     """Find all versions affected by a cve."""
     result = set()
 
-    affected_products = cve['affects']['vendor']['vendor_data']
-    for products in affected_products:
-        products = products['product']['product_data']
-        for product in products:
-            versions = product['version']['version_data']
-            product = product['product_name']
-            for version in versions:
-                version = version['version_value']
+    if 'affects' in cve:
+        affected_products = cve['affects']['vendor']['vendor_data']
+        for products in affected_products:
+            products = products['product']['product_data']
+            for product in products:
+                versions = product['version']['version_data']
+                product = product['product_name']
+                for version in versions:
+                    version = version['version_value']
 
-                result.update(match_str_to_software_version(product, version))
+                    result.update(match_str_to_software_version(product, version))
     return result
 
 
 def cve_stats_for_year(year: int) -> Dict[SoftwareVersion, Set[str]]:
-    url = 'https://static.nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-{}.json.gz'.format(
+    url = 'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{}.json.gz'.format(
         year)
     cve_items = json.loads(
         decompress(requests.get(url).content).decode())['CVE_Items']


### PR DESCRIPTION
The currently used API for fetching the CVE feed is deprecated (see [1][1] and [2][2]). The old API is still available but with another URL and slightly different schema ([3][3]).

This PR introduces a workaround to use the legacy API with the updated URL and changed schema.

[1]: https://nvd.nist.gov/General/News/New-NVD-CVE-CPE-API-and-SOAP-Retirement
[2]: https://csrc.nist.gov/CSRC/media/Projects/National-Vulnerability-Database/documents/web%20service%20documentation/Automation%20Support%20for%20CVE%20Retrieval.pdf
[3]: https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog